### PR TITLE
Enable logs & update PR template

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=False &
+pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=True &
 
 # Output to the screen every 9 minutes to prevent a travis timeout
 # https://stackoverflow.com/a/40800348

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,28 @@
-## Summary
+## What's this PR do?
+<!-- eg. This PR updates the scraper for Cleveland City Council because of changes to how they display their meeting schedule. -->
 
-**Issue:** #ISSUE_NUMBER
+## Why are we doing this?
+<!-- eg. The website's layout was recently updated, causing our existing scraper to fail. This change ensures our scraper remains functional and continues to provide timely updates on council meetings. -->
 
-Replace "ISSUE_NUMBER" with the number of your issue so that GitHub will link this pull request with the issue and make review easier.
+## Steps to manually test
+<!-- Text here is not always necessary but it is generally recommended in order to aid a reviewer.
+eg.
+1. Ensure the project is installed:
+```
+pipenv sync --dev
+```
+2. Activate the virtual env and enter the pipenv shell:
+```
+pipenv shell
+```
+3. Run the spider:
+```
+scrapy crawl <spider-name> -O test_output.csv
+```
+4. Monitor the output and ensure no errors are raised.
 
-## Checklist
+5. Inspect `test_output.csv` to ensure the data looks valid.
+-->
 
-All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.
-
-- [ ] Tests are implemented
-- [ ] All tests are passing
-- [ ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
-- [ ] Style checks are passing
-- [ ] Code comments from template removed
-
-## Questions
-
-Include any questions you have about what you're working on.
+## Are there any smells or added technical debt to note?
+<!-- eg. The new scraping logic includes a more complex parsing routine, which might be less efficient. Future optimization or a more robust parsing strategy may be needed if the website's layout continues to evolve. -->


### PR DESCRIPTION
## What's this PR do?
Enables logs during production scraper runs and updates the PR template to the same style as the current [city-scrapers template repo](https://github.com/City-Bureau/city-scrapers-template).

## Why are we doing this?
Logs are helpful for diagnosing production issues. The PR template update ensures we have some uniformity among our repos.

## Steps to manually test
N/A

## Are there any smells or added technical debt to note?
N/A