### PR TITLE
🕷️ Fix spider: MARTA Board of Directors

### DIFF
--- a/city_scrapers/spiders/atl_marta_board.py
+++ b/city_scrapers/spiders/atl_marta_board.py
@@ -11,6 +11,10 @@ class AtlMartaBoardSpider(CityScrapersSpider):
     agency = "MARTA Board of Directors"
     timezone = "America/New_York"
     start_urls = ["https://www.itsmarta.com/meeting-schedule.aspx"]
+    location = {
+        "name": "MARTA Headquarters",
+        "address": "2424 Piedmont Rd NE Atlanta, GA 30324",
+    }
 
     def parse(self, response):
         # not a lot here, just dates and titles
@@ -35,15 +39,12 @@ class AtlMartaBoardSpider(CityScrapersSpider):
                 end=None,
                 all_day=False,
                 time_notes="",
+                location=self.location,
                 links=[],
-                source=self._parse_source(response),
+                source=response.url,
             )
 
             meeting["status"] = self._get_status(meeting)
             meeting["id"] = self._get_id(meeting)
 
             yield meeting
-
-    def _parse_source(self, response):
-        """Parse or generate source."""
-        return response.url


### PR DESCRIPTION
## What's this PR do?

Fixes our MARTA Board of Directors spider (aka. `atl_marta_board`).

## Why are we doing this?

This spider appears to work locally but has been failing for a long time in production because it doesn't return a location.

## Steps to manually test

After installing the project using `pipenv`:

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl atl_marta_board -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note?
