### PR TITLE
Update city-scrapers-core to v0.11.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -232,7 +232,7 @@
             ],
             "git": "https://github.com/City-Bureau/city-scrapers-core.git",
             "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "ref": "78ccb55766bc445eb2c685bd40a769ce673cb2ee"
+            "ref": "1d06f640cdcfd5986e089379a134f8aec35ce2a9"
         },
         "constantly": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Update city-scrapers-core pinned commit in Pipfile.lock to v0.11.0

## Test plan
- [ ] Verify CI passes