### PR TITLE
Add staging workflow and settings

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,84 @@
+name: Staging
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+env:
+  CI: true
+  PYTHON_VERSION: 3.11
+  PIPENV_VENV_IN_PROJECT: true
+  CITY_SCRAPERS_ENV: staging
+  SCRAPY_SETTINGS_MODULE: city_scrapers.settings.staging
+  AUTOTHROTTLE_MAX_DELAY: 30.0
+  AUTOTHROTTLE_START_DELAY: 1.5
+  AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
+  AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+  AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+  AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Pipenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ env.PYTHON_VERSION }}-
+            pip-
+
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
+      - name: Install dependencies
+        run: pipenv sync
+        env:
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+
+      - name: Run scrapers
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          ./.deploy.sh
+
+      - name: Combine output feeds
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/city_scrapers/settings/staging.py
+++ b/city_scrapers/settings/staging.py
@@ -1,0 +1,42 @@
+import os
+
+from .base import *  # noqa
+
+USER_AGENT = "City Scrapers [staging mode]. Learn more and say hello at https://citybureau.org/city-scrapers"  # noqa
+
+ITEM_PIPELINES = {
+    "city_scrapers_core.pipelines.AzureDiffPipeline": 200,
+    "city_scrapers_core.pipelines.MeetingPipeline": 300,
+    "city_scrapers_core.pipelines.OpenCivicDataPipeline": 400,
+}
+
+SENTRY_DSN = os.getenv("SENTRY_DSN")
+
+EXTENSIONS = {
+    "scrapy_sentry_errors.extensions.Errors": 10,
+    "scrapy.extensions.closespider.CloseSpider": None,
+}
+
+FEED_EXPORTERS = {
+    "json": "scrapy.exporters.JsonItemExporter",
+    "jsonlines": "scrapy.exporters.JsonLinesItemExporter",
+}
+
+FEED_FORMAT = "jsonlines"
+
+FEED_STORAGES = {
+    "azure": "city_scrapers_core.extensions.AzureBlobFeedStorage",
+}
+
+AZURE_ACCOUNT_NAME = os.getenv("AZURE_ACCOUNT_NAME")
+AZURE_ACCOUNT_KEY = os.getenv("AZURE_ACCOUNT_KEY")
+AZURE_CONTAINER = os.getenv("AZURE_STAGING_CONTAINER")
+
+FEED_URI = (
+    "azure://{account_name}:{account_key}@{container}"
+    "/%(year)s/%(month)s/%(day)s/%(hour_min)s/%(name)s.json"
+).format(
+    account_name=AZURE_ACCOUNT_NAME,
+    account_key=AZURE_ACCOUNT_KEY,
+    container=AZURE_CONTAINER,
+)


### PR DESCRIPTION
## Summary
- Add `.github/workflows/staging.yml` — runs daily at 05:00 UTC, on push to `staging`, and via manual dispatch
- Add `city_scrapers/settings/staging.py` — staging settings module that writes feeds to the staging Azure container

Modeled on [city-scrapers-fortx#33](https://github.com/City-Bureau/city-scrapers-fortx/pull/33).

## Test plan
- [ ] Add `AZURE_STAGING_CONTAINER` secret in repo settings
- [ ] Create a `staging` branch so the workflow's `checkout ref: staging` resolves
- [ ] Trigger the workflow via `workflow_dispatch` and confirm scrapers run and feeds land in the staging container