### PR TITLE
Add OpenVPN connect step to cron workflow

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -13,12 +13,25 @@ env:
   AUTOTHROTTLE_MAX_DELAY: 30.0
   AUTOTHROTTLE_START_DELAY: 1.5
   AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
+  OPENVPN_USER: ${{ secrets.OPENVPN_USER }}
+  OPENVPN_PASS: ${{ secrets.OPENVPN_PASS }}
+  OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}
 
 jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Connect to OpenVPN
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openvpn
+          echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
+          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
+          sleep 120
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,17 +31,29 @@ jobs:
 
       - name: Connect to OpenVPN
         run: |
+          echo "=== OpenVPN connect step v4 ==="
           sudo apt-get update
           sudo apt-get install -y openvpn
-          echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
-          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
-          echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
-          # Strip Windows-only directives that the Linux OpenVPN client rejects
-          sudo sed -i '/^block-outside-dns/d' /etc/openvpn/ovpn.conf
+          echo "$OPENVPN_USER" | sudo tee /etc/openvpn/client/auth >/dev/null
+          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth >/dev/null
+          echo "$OPENVPN_CONFIG" > /tmp/raw.ovpn
+
+          # Strip Windows-only directives + tolerate any future unknown options
+          sed -E '/(^|[[:space:]])(block-outside-dns|register-dns)([[:space:]]|$)/d' /tmp/raw.ovpn > /tmp/clean.ovpn
+          {
+            echo "ignore-unknown-option block-outside-dns register-dns"
+            cat /tmp/clean.ovpn
+          } | sudo tee /etc/openvpn/ovpn.conf >/dev/null
+
+          echo "--- config lines that mention 'outside-dns' (should be empty) ---"
+          sudo grep -n "outside-dns" /etc/openvpn/ovpn.conf || echo "(none)"
+
           sudo openvpn --config /etc/openvpn/ovpn.conf --daemon --log /tmp/openvpn.log
-          sleep 30
+          sleep 20
           echo "--- /tmp/openvpn.log (tail) ---"
-          sudo tail -50 /tmp/openvpn.log || true
+          sudo tail -80 /tmp/openvpn.log || true
+          echo "--- ip addr show tun0 ---"
+          ip -brief addr show tun0 || echo "(no tun0)"
 
       - name: Verify VPN egress IP
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -39,6 +39,14 @@ jobs:
           sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
           sleep 120
 
+      - name: Verify VPN egress IP
+        run: |
+          echo "Public IPv4 seen by external services:"
+          curl -s --max-time 10 https://ifconfig.me || true
+          echo
+          echo "tun interface status:"
+          ip -brief addr show tun0 || echo "no tun0 interface"
+
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,37 +31,13 @@ jobs:
 
       - name: Connect to OpenVPN
         run: |
-          echo "=== OpenVPN connect step v4 ==="
           sudo apt-get update
           sudo apt-get install -y openvpn
-          echo "$OPENVPN_USER" | sudo tee /etc/openvpn/client/auth >/dev/null
-          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth >/dev/null
-          echo "$OPENVPN_CONFIG" > /tmp/raw.ovpn
-
-          # Strip Windows-only directives + tolerate any future unknown options
-          sed -E '/(^|[[:space:]])(block-outside-dns|register-dns)([[:space:]]|$)/d' /tmp/raw.ovpn > /tmp/clean.ovpn
-          {
-            echo "ignore-unknown-option block-outside-dns register-dns"
-            cat /tmp/clean.ovpn
-          } | sudo tee /etc/openvpn/ovpn.conf >/dev/null
-
-          echo "--- config lines that mention 'outside-dns' (should be empty) ---"
-          sudo grep -n "outside-dns" /etc/openvpn/ovpn.conf || echo "(none)"
-
-          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon --log /tmp/openvpn.log
-          sleep 20
-          echo "--- /tmp/openvpn.log (tail) ---"
-          sudo tail -80 /tmp/openvpn.log || true
-          echo "--- ip addr show tun0 ---"
-          ip -brief addr show tun0 || echo "(no tun0)"
-
-      - name: Verify VPN egress IP
-        run: |
-          echo "Public IPv4 seen by external services:"
-          curl -s --max-time 10 https://ifconfig.me || true
-          echo
-          echo "tun interface status:"
-          ip -brief addr show tun0 || echo "no tun0 interface"
+          echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
+          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
+          sleep 120
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,12 +19,25 @@ env:
   AZURE_CONTAINER: ${{ secrets.AZURE_CONTAINER }}
   AZURE_STATUS_CONTAINER: ${{ secrets.AZURE_STATUS_CONTAINER }}
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  OPENVPN_USER: ${{ secrets.OPENVPN_USER }}
+  OPENVPN_PASS: ${{ secrets.OPENVPN_PASS }}
+  OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}
 
 jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Connect to OpenVPN
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openvpn
+          echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
+          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
+          sleep 120
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -36,8 +36,12 @@ jobs:
           echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
           echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
           echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
-          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
-          sleep 120
+          # Strip Windows-only directives that the Linux OpenVPN client rejects
+          sudo sed -i '/^block-outside-dns/d' /etc/openvpn/ovpn.conf
+          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon --log /tmp/openvpn.log
+          sleep 30
+          echo "--- /tmp/openvpn.log (tail) ---"
+          sudo tail -50 /tmp/openvpn.log || true
 
       - name: Verify VPN egress IP
         run: |

--- a/.github/workflows/refresh-staging.yml
+++ b/.github/workflows/refresh-staging.yml
@@ -175,6 +175,9 @@ jobs:
       AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
       AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      OPENVPN_USER: ${{ secrets.OPENVPN_USER }}
+      OPENVPN_PASS: ${{ secrets.OPENVPN_PASS }}
+      OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}
     steps:
       - name: Clean Azure staging container
         run: |
@@ -186,6 +189,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: staging
+
+      - name: Connect to OpenVPN
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openvpn
+          echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
+          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
+          sleep 120
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,6 +21,9 @@ env:
   AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
   AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  OPENVPN_USER: ${{ secrets.OPENVPN_USER }}
+  OPENVPN_PASS: ${{ secrets.OPENVPN_PASS }}
+  OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}
 
 jobs:
   crawl:
@@ -29,6 +32,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: staging
+
+      - name: Connect to OpenVPN
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openvpn
+          echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth
+          echo "$OPENVPN_CONFIG" | sudo tee -a /etc/openvpn/ovpn.conf
+          sudo openvpn --config /etc/openvpn/ovpn.conf --daemon
+          sleep 120
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Add OpenVPN connect step to `cron.yml` before the Python setup steps.
- Read three secrets (`OPENVPN_USER`, `OPENVPN_PASS`, `OPENVPN_CONFIG`) — same shape used by city-scrapers-cle so the new self-hosted VPN server (`vpn.city-scrapers.org`) can be tested here first.

## Test plan
- [ ] Trigger workflow manually (`Run workflow` button) and confirm the `Connect to OpenVPN` step completes without error.
- [ ] Verify `curl ifconfig.me` (or scraper egress IP visible in Sentry / logs) is the VPN server IP, not GitHub's runner IP.
- [ ] Confirm scraper run + Azure upload still succeed.